### PR TITLE
Cleanup ansible-lint reported complaints.

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,21 +1,11 @@
-# Ensure that the following ansible-lint rule failures are treated as
-# warnings rather than errors.
-warn_list:
-  # We don't necessarily care about providing the galaxy_info settings
-  # in our roles right now as they are currently for private/internal
-  # use only.
-  - meta-no-info  # meta/main.yml should contain relevant info.
+# In some cases lint failures can be tolerated, and converted to warnings
+# rather than errors. If desired add the rules to this list.
+warn_list: []
 
-  # ansible-lint complains that tasks which are triggered as a result of
-  # another task having a changed status should be implemented as handlers.
-  # However this is sometimes not possible (e.g. meta reset_connection
-  # doesn't like running under a handler) or not desirable (e.g. if the
-  # system packages have been updated or hostname has been changed we want
-  # to trigger the reboot at the specific point in the play, before we
-  # continue on to setup any services that may have been updated or freshly
-  # installed.
-  - no-handler  # Tasks that run when changed should likely be handlers.
+# NOTE: To completely hide complaints about any rule failures, rather
+# than just converting them to non-fatal warnings, simply move them to
+# a `skip_list` item instead.
+skip_list: []
 
-# NOTE: To completely hide complaints about any of the above rules, rather
-# than just converting them to non-fatal warnings, simply move them to a
-# `skip_list` item instead.
+# Run full action validation, similar to what Ansible syntax checking does.
+skip_action_validation: false

--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -1,0 +1,4 @@
+# This file contains ignores rule violations for ansible-lint
+settings/config.yml yaml[comments]
+settings/libvirt_host.yml yaml[comments]
+settings/vms.yml yaml[comments]

--- a/README.md
+++ b/README.md
@@ -184,6 +184,19 @@ Have a lot of fun...
 testenv@alptestvm:~>
 ```
 
+
+# Contributing
+
+The code should pass validation with `bin/ansible-lint` (version 6.14 as
+of writing), noting that 'yaml[comments]' are explicitly ignored for
+the `settings/*.yml` files that may have been created.
+
+## Some rules explicitly ignored in code
+Some `# noqa ...` comment markers exist in the code to explicitly ignore
+certain rules, such as complaints that handlers should be used for actions
+that run because something has changed.
+
+
 # Future Enhancements
 
 TODO:

--- a/ansible/check_config_settings.yml
+++ b/ansible/check_config_settings.yml
@@ -1,6 +1,7 @@
 ---
 
-- hosts: localhost
+- name: Check configuation settings are setup and appropriate
+  hosts: localhost
   gather_facts: false
   tasks:
 
@@ -14,13 +15,13 @@
       ansible.builtin.copy:
         src: "{{ [playbook_dir | dirname, 'settings', item.item] | join('/') }}.example"
         dest: "{{ [playbook_dir | dirname, 'settings', item.item] | join('/') }}"
-        mode: 0644
+        mode: "0644"
       loop: "{{ stat_required_settings.results }}"
       loop_control:
         label: "{{ item.item }}"
       register: copy_required_settings
 
-    - name: Report if required settings files were created
+    - name: Report if required settings files were created  # noqa no-handler
       ansible.builtin.debug:
         msg: >-
           Required settings files have been setup.
@@ -49,4 +50,3 @@
           No 'vnet_configs' settings detected.
           Did you copy settings/vnets.yml.example to settings/vnets.yml and
           customise it?
-

--- a/ansible/group_vars/all/managed_vms.yml
+++ b/ansible/group_vars/all/managed_vms.yml
@@ -3,7 +3,7 @@
 managed_vms: >-
   {%- set _managed_vms = [] -%}
   {%- for _vm in vm_configs | default([]) -%}
-  {%-   set _mgmt_nics = _vm.nics | selectattr('nettype', 'eq', 'network') 
+  {%-   set _mgmt_nics = _vm.nics | selectattr('nettype', 'eq', 'network')
                                   | selectattr('netdev', 'eq',
                                                vm_mgmt_net |
                                                default('alpmgmt'))

--- a/ansible/roles/alp_image_details/tasks/main.yml
+++ b/ansible/roles/alp_image_details/tasks/main.yml
@@ -4,14 +4,14 @@
 # is first loaded, so that we retain a consistent value for the
 # duration of an ansible-playbook run.
 - name: Resolve alp_image_name
-  set_fact:
+  ansible.builtin.set_fact:
     alp_image_name: "{{ _alp_image_name }}"
   when:
     - alp_image_name is not defined
   register: dynamic_image_name
 
 - name: Show calculated ALP image name
-  debug:
+  ansible.builtin.debug:
     var: alp_image_name
   when:
     - dynamic_image_name is not skipped

--- a/ansible/roles/alp_vm/tasks/create_vm.yml
+++ b/ansible/roles/alp_vm/tasks/create_vm.yml
@@ -9,14 +9,14 @@
   ansible.builtin.copy:
     src: "{{ alp_image.cached }}"
     dest: "{{ alp_vm.image.backing }}"
-    mode: 0644
+    mode: "0644"
     remote_src: true
 
 - name: Create ignition config file
   ansible.builtin.template:
     src: "{{ alp_vm.ignition.template }}"
     dest: "{{ alp_vm.ignition.file }}"
-    mode: 0600
+    mode: "0600"
 
 - name: Create VM {{ alp_vm.name }}
   become: true

--- a/ansible/roles/alp_workload/defaults/main.yml
+++ b/ansible/roles/alp_workload/defaults/main.yml
@@ -3,7 +3,7 @@
 _def_container:
   # podman pull registry.opensuse.org/suse/alp/workloads/tumbleweed_containerfiles/suse/alp/workloads/gdm:latest
   name: "{{ workload.name }}"
-  registry:  registry.opensuse.org
+  registry: registry.opensuse.org
   path: suse/alp/workloads/tumbleweed_containerfiles/suse/alp/workloads
   version: latest
 

--- a/ansible/roles/alp_workload/tasks/get_image.yml
+++ b/ansible/roles/alp_workload/tasks/get_image.yml
@@ -19,7 +19,7 @@
   delegate_to: "{{ groups.alp_vms | first }}"
   run_once: true
   ansible.builtin.stat:
-    path:  "{{ workload_image.file.path }}"
+    path: "{{ workload_image.file.path }}"
     get_attributes: false
     get_checksum: false
     get_mime: false
@@ -48,6 +48,7 @@
   ansible.builtin.copy:
     src: "{{ workload_image.file.path }}"
     dest: "{{ workload_image.file.path | dirname }}"
+    mode: "0644"
   when:
     - inventory_hostname != (groups.alp_vms | first)
   register: workload_image_cache_copy

--- a/ansible/roles/alp_workload/tasks/install_workload.yml
+++ b/ansible/roles/alp_workload/tasks/install_workload.yml
@@ -4,7 +4,7 @@
   ansible.builtin.file:
     path: "{{ alp.cache.workloads }}"
     state: directory
-    mode: 0755
+    mode: "0755"
 
 - name: Check if container already available as root for workload {{ alp_workload.name }}
   become: true
@@ -19,7 +19,7 @@
 
 - name: Install container tools for workload {{ alp_workload.name }}
   become: true
-  command: >-
+  ansible.builtin.command: >-
     podman container runlabel {{ alp_workload.labels.install }} {{ alp_workload.image }}
   changed_when: false
   register: workload_runlabel_install

--- a/ansible/roles/get_alp_image/tasks/main.yml
+++ b/ansible/roles/get_alp_image/tasks/main.yml
@@ -4,14 +4,14 @@
   ansible.builtin.file:
     path: "{{ alp.cache.images }}"
     state: directory
-    mode: 0755
+    mode: "0755"
 
 - name: Download ALP image to cache if needed
   ansible.builtin.get_url:
     dest: "{{ alp_image.cached }}"
     url: "{{ alp_image.url }}"
     checksum: "{{ alp_image.checksum }}"
-    mode: 0644
+    mode: "0644"
   register: alp_image_download
 
 - name: Report image that was downloaded

--- a/settings/config.yml.example
+++ b/settings/config.yml.example
@@ -5,16 +5,16 @@
 #
 
 # The ALP arch to target
-#alp_arch: 'x86_64'  # noqa yaml[comments]
+#alp_arch: 'x86_64'
 
 # Choice of 'kvm' or 'kvm_encrypted'
-#alp_image_type: kvm  # noqa yaml[comments]
+#alp_image_type: kvm
 
 # Choice of 'build' or 'snapshot'
-#alp_build_type: build  # noqa yaml[comments]
+#alp_build_type: build
 
 # SSH Public Keys to Register
-#ssh_pub_keys:  # noqa yaml[comments]
+#ssh_pub_keys:
 #  files:
 #    - ~/.ssh/id_ed25519.pub
 #    - ~/.ssh/id_rsa.pub

--- a/settings/libvirt_host.yml.example
+++ b/settings/libvirt_host.yml.example
@@ -5,17 +5,17 @@
 # If you wish to remotely use a libvirt host from your
 # workstation then uncomment the following lines, and
 # configure the settings appropriately
-#libvirt_host_type: remote  # noqa yaml[comments]
+#libvirt_host_type: remote
 
 # IP address of the libvirt host you are using
-#libvirt_host_ip: 192.168.123.45  # noqa yaml[comments]
-#libvirt_host_name: remote_host  # noqa yaml[comments]
-#libvirt_host_group: libvirt_hosts  # noqa yaml[comments]
+#libvirt_host_ip: 192.168.123.45
+#libvirt_host_name: remote_host
+#libvirt_host_group: libvirt_hosts
 
 # User account to connect to on the remote libvirt host if
 # not the same as the current user.
-#libvirt_host_user: remote_user  # noqa yaml[comments]
+#libvirt_host_user: remote_user
 
 # Explicitly specify the python interpretter to use on
 # the remote libvirt host if needed.
-#libvirt_host_python: /usr/bin/python3  # noqa yaml[comments]
+#libvirt_host_python: /usr/bin/python3

--- a/settings/packages.yml.example
+++ b/settings/packages.yml.example
@@ -2,8 +2,8 @@
 
 alp_packages:
   required:
-    #- bzip2  # needed for tar.bz2 in ansible.builtin.unarchive
-    #- e2fsprogs  # needed for formatting ext2/3/4 file systems
+#   - bzip2  # needed for tar.bz2 in ansible.builtin.unarchive
+#   - e2fsprogs  # needed for formatting ext2/3/4 file systems
     - kernel-default  # need complete set of kernel modules
     - "-kernel-default-base"  # remove to avoid conflict
     - netcat-openbsd  # needed for remote virsh interaction


### PR DESCRIPTION
Also cleanup the .ansible-lint file to remove rules that no longer need to be converted to warnings.

Added .ansible-lint-ignore with entries to ignore failures for commented out lines in YAML settings files under settings/.

Added a Contributing section to the README.md discussing the fact that the code should pass ansible-lint testing.