### PR TITLE
Fix quick start process and update README.md to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ $ bin/ansible-playbook ansible/test_env_create.yml
 ```
 
 Doing so will automatically setup the `vms.yml` and `vnets.yml` files
-under the `settings/` directory using the corresponding example files,
-and, all going well, should create a Libvirt managed ALP VM, called
-`alptestvm`, on the local system, with the Ansible workload for ALP
-installed, that you can log in to using the generated SSH config file,
-`ssh/config`, as follows:
+under the `settings/` directory using the corresponding example files
+and fail, asking you to re-run the playbook.
+
+When you re-run the playbook, as requested, it should create, all going
+well, a Libvirt managed ALP VM, called `alptestvm`, on the local system,
+with the Ansible workload for ALP installed, that you can log in to using
+the generated SSH config file, `ssh/config`, as follows:
 
 ```shell
 $ ssh -F ssh/config alptestvm

--- a/ansible/check_config_settings.yml
+++ b/ansible/check_config_settings.yml
@@ -19,13 +19,16 @@
       loop: "{{ stat_required_settings.results }}"
       loop_control:
         label: "{{ item.item }}"
+      when:
+        - not item.stat.exists
       register: copy_required_settings
 
     - name: Report if required settings files were created  # noqa no-handler
-      ansible.builtin.debug:
+      ansible.builtin.fail:
         msg: >-
           Required settings files have been setup.
-          Please customise as needed.
+          Please customise as needed and re-run this playbook to avail of
+          these changes.
       when:
         - copy_required_settings is changed
 


### PR DESCRIPTION
After creating the relevant settings files the playbook needs to be re-run to pick up the relevant settings via the symlinks under the group_vars directory, so add a fail action telling the user to do so.